### PR TITLE
[WH][000000] added accept_header strategy

### DIFF
--- a/lib/strategies/accept_header_strategy.rb
+++ b/lib/strategies/accept_header_strategy.rb
@@ -1,0 +1,42 @@
+module Phenotype
+  class AcceptHeaderStrategy
+    attr_reader :env, :content_type, :version_key
+
+    def initialize(app_name: 'rentpath',
+                   version_key: 'version', 
+                   format: 'json')
+      @version_key = version_key
+      @content_type = build_content_type(app_name, format)
+    end
+
+    def get_version(env)
+      @env = env
+      version
+    end
+
+    def version
+      version_content = accept_header_hash[content_type]
+      return unless version_content
+      version_content.split("#{version_key}=")[1]
+    end
+
+    private
+    def build_content_type(app_name, format)
+      "application/vnd.#{app_name}.api+#{format}"
+    end
+
+    def accept_header_hash
+      accepted_content.reduce({}) do |header_hash, content|
+        key, value = content.split(';')
+        header_hash[key] = value
+        header_hash
+      end
+    end
+
+    def accepted_content
+      accept_header = env['HTTP_ACCEPT']
+      return [] unless accept_header 
+      accept_header.strip.split(',')
+    end
+  end
+end

--- a/lib/util/version.rb
+++ b/lib/util/version.rb
@@ -1,3 +1,3 @@
 module Phenotype
-  VERSION = '0.1.0'
+  VERSION = '0.2.0'
 end

--- a/spec/strategies/accept_header_strategy_spec.rb
+++ b/spec/strategies/accept_header_strategy_spec.rb
@@ -1,0 +1,43 @@
+require "spec_helper"
+
+describe Phenotype::AcceptHeaderStrategy do
+  describe "#get_version" do
+    subject { described_class.new }
+
+    context "with the version as the only accept header" do
+      let(:env) do
+        env = Rack::MockRequest.env_for('/foo')
+        env['HTTP_ACCEPT'] = 'application/vnd.rentpath.api+json;version=1'
+        env
+      end
+
+      it "returns the correct version" do
+        expect(subject.get_version(env)).to eql('1')
+        env['HTTP_ACCEPT'] = 'application/vnd.rentpath.api+json;version=2'
+        expect(subject.get_version(env)).to eql("2")
+      end
+    end
+
+    context "with no accept header" do
+      let(:env) do
+        Rack::MockRequest.env_for('/foo')
+      end
+
+      it 'returns nil ' do
+        expect(subject.get_version(env)).to be_nil
+      end
+    end
+
+    context "with an accept header without the expected values" do
+      let(:env) do
+        env = Rack::MockRequest.env_for('/foo')
+        env['HTTP_ACCEPT'] = 'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8'
+        env
+      end
+
+      it 'returns nil ' do
+        expect(subject.get_version(env)).to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
Per our new API standards, we are now using the accept header to version our apps. 
