### PR TITLE
Update the path when cascading versions

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     phenotype (0.4.1)
-      rack (~> 2.0)
+      rack (~> 1.6)
       require_all (~> 1.3)
 
 GEM
@@ -23,7 +23,7 @@ GEM
     pry-byebug (3.6.0)
       byebug (~> 10.0)
       pry (~> 0.10)
-    rack (2.0.4)
+    rack (1.6.10)
     rainbow (3.0.0)
     rake (10.5.0)
     require_all (1.5.0)
@@ -62,4 +62,4 @@ DEPENDENCIES
   rubocop
 
 BUNDLED WITH
-   1.16.0
+   1.16.1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     phenotype (0.4.1)
-      rack (~> 1.6)
+      rack (~> 1)
       require_all (~> 1.3)
 
 GEM
@@ -62,4 +62,4 @@ DEPENDENCIES
   rubocop
 
 BUNDLED WITH
-   1.16.1
+   1.16.3

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    phenotype (0.4.1)
+    phenotype (0.4.2)
       rack (~> 1)
       require_all (~> 1.3)
 

--- a/lib/phenotype/version.rb
+++ b/lib/phenotype/version.rb
@@ -1,3 +1,3 @@
 module Phenotype
-  VERSION = '0.4.1'.freeze
+  VERSION = '0.4.2'.freeze
 end

--- a/lib/phenotype/versioner.rb
+++ b/lib/phenotype/versioner.rb
@@ -14,7 +14,7 @@ module Phenotype
     def call
       return display_errors if errors?
       cascading_versions.each do |v|
-        if strategies.first.kind_of?(PathStrategy) && version_mismatch?(v)
+        if strategies.first.instance_of?(PathStrategy) && version_mismatch?(v)
           env['PATH_INFO'] = updated_versioned_path(env['PATH_INFO'], v)
         end
         route = call_route(v)
@@ -26,7 +26,7 @@ module Phenotype
     private
 
     def version_mismatch?(version)
-      path_version && path_version != version.to_s
+      path_version && (path_version != version.to_s)
     end
 
     def path_version

--- a/phenotype.gemspec
+++ b/phenotype.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
 
   s.add_development_dependency 'pry', '~> 0.10'
-  s.add_dependency 'rack', '~> 2.0'
+  s.add_dependency 'rack', '~> 1.6'
   s.add_dependency 'require_all', '~> 1.3'
   s.add_development_dependency 'rake', '~> 10.5'
   s.add_development_dependency 'rspec', '~> 3.4'

--- a/phenotype.gemspec
+++ b/phenotype.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
 
   s.add_development_dependency 'pry', '~> 0.10'
-  s.add_dependency 'rack', '~> 1.6'
+  s.add_dependency 'rack', '~> 1'
   s.add_dependency 'require_all', '~> 1.3'
   s.add_development_dependency 'rake', '~> 10.5'
   s.add_development_dependency 'rspec', '~> 3.4'


### PR DESCRIPTION
[Story](https://rentpath.leankit.com/card/680082820)

When an app is configured to use cascading versions and the versioning strategy is path-based, it wouldn't work.  When attempting to find a path to use as a fallback you would get a 404 because obviously no e.g. `/v3/` path would exist in the V2 app.  This updates the path used.